### PR TITLE
add form fields output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.idea
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ The Preserve Query String filter allows you to add `|preserveQueryStrings` to an
 
 E.g.
 
-```
+```twig
 {% if pageInfo.prevUrl %}<a href="{{ pageInfo.prevUrl|preserveQueryStrings }}">Previous Page</a>{% endif %}
 {% if pageInfo.nextUrl %}<a href="{{ pageInfo.nextUrl|preserveQueryStrings }}">Next Page</a>{% endif %}
 ```
-
 
 ## getQueryStrings
 
@@ -27,16 +26,32 @@ An array will be returned with objects. Use `.key` and `.value`.
 
 ### Return all URL queries
 
-```
+```twig
 {% for query in getQueryStrings() %}
-	{{ query.key }} - {{ query.value }}
+  {{ query.key }} - {{ query.value }}
 {% endfor %}
 ```
 
 ### Return only URL queries that match a key
 
-```
+```twig
 {% for query in getQueryStrings('lookForKey') %}
-	{{ query.key }} - {{ query.value }}
+  {{ query.key }} - {{ query.value }}
+{% endfor %}
+```
+
+## getQueryFormFields
+
+Sometimes you want to use query fields in a form, to preserve these values you can use the following in your templates.
+
+```twig
+{{ getQueryFormFields() }}
+```
+
+which is shorthand/equivalent to:
+
+```twig
+{% for query in getQueryStrings() %}
+  <input type="hidden" name="{{ query.key }}" value="{{ query.value }}">
 {% endfor %}
 ```

--- a/querystrings/twigextensions/QueryStringsTwigExtension.php
+++ b/querystrings/twigextensions/QueryStringsTwigExtension.php
@@ -24,7 +24,8 @@ class QueryStringsTwigExtension extends Twig_Extension
   {
     return array(
       // 'getQueryStrings' => new Twig_Function('getQueryStrings', 'getQueryStrings'),
-        'getQueryStrings' => new \Twig_SimpleFunction('getQueryStrings', array($this, 'getQueryStrings'), array('is_safe' => array('html'))),
+        'getQueryStrings'    => new \Twig_SimpleFunction('getQueryStrings', array($this, 'getQueryStrings'), array('is_safe' => array('html'))),
+        'getQueryFormFields' => new \Twig_SimpleFunction('getQueryFormFields', array($this, 'getQueryFormFields'), array('is_safe' => array('html'))),
     );
   }
 
@@ -36,7 +37,7 @@ class QueryStringsTwigExtension extends Twig_Extension
 
     foreach ($queryStrings as $string)
     {
-      $return .= "<input type=\"hidden\" name=\"{$string['key']}\" value=\"{$string['value']}\">\n" ;
+      $return .= "<input type=\"hidden\" name=\"{$string['key']}\" value=\"{$string['value']}\">\n";
     }
 
     return TemplateHelper::getRaw($return);

--- a/querystrings/twigextensions/QueryStringsTwigExtension.php
+++ b/querystrings/twigextensions/QueryStringsTwigExtension.php
@@ -5,65 +5,88 @@ namespace Craft;
 use Twig_Extension;
 use Twig_Filter_Method;
 
-class QueryStringsTwigExtension extends Twig_Extension {
+class QueryStringsTwigExtension extends Twig_Extension
+{
 
-	public function getName()
-	{
-		return 'Query Strings';
-	}
+  public function getName()
+  {
+    return 'Query Strings';
+  }
 
-	public function getFilters()
-	{
-		return array(
-      'preserveQueryStrings' => new Twig_Filter_Method($this, 'preserveQueryStrings')
-		);
-	}
+  public function getFilters()
+  {
+    return array(
+        'preserveQueryStrings' => new Twig_Filter_Method($this, 'preserveQueryStrings'),
+    );
+  }
 
   public function getFunctions()
+  {
+    return array(
+      // 'getQueryStrings' => new Twig_Function('getQueryStrings', 'getQueryStrings'),
+        'getQueryStrings' => new \Twig_SimpleFunction('getQueryStrings', array($this, 'getQueryStrings'), array('is_safe' => array('html'))),
+    );
+  }
+
+
+  public function getQueryFormFields()
+  {
+    $queryStrings = $this->getQueryStrings();
+    $return       = '';
+
+    foreach ($queryStrings as $string)
     {
-        return array(
-           // 'getQueryStrings' => new Twig_Function('getQueryStrings', 'getQueryStrings'),
-           'getQueryStrings' => new \Twig_SimpleFunction('getQueryStrings', array($this, 'getQueryStrings'), array('is_safe' => array('html')))
-        );
+      $return .= "<input type=\"hidden\" name=\"{$string['key']}\" value=\"{$string['value']}\">\n" ;
     }
-  
+
+    return TemplateHelper::getRaw($return);
+  }
+
   public function preserveQueryStrings($url)
   {
-    if (substr(craft()->request->queryString, 0,2) == "p=") {
+    if (substr(craft()->request->queryString, 0, 2) == "p=")
+    {
       $queries = explode("&", craft()->request->queryString, 2);
 
-      if (sizeof($queries) > 1) {
+      if (sizeof($queries) > 1)
+      {
         $queryStrings = $queries[1];
-      } else {
+      } else
+      {
         return TemplateHelper::getRaw($url);
       }
     }
 
-    if (substr($url,-1) != "?") {
+    if (substr($url, -1) != "?")
+    {
       $return = $url . "?";
-    } else {
+    } else
+    {
       $return = $url;
     }
 
     $return = $return . $queryStrings;
-    
+
     return TemplateHelper::getRaw($return);
   }
 
   public function getQueryStrings($lookForKey = false)
   {
-      
+
     // Get the query string from Craft and break it apart for use in templates
-  
+
     // Break query apart to remove page information if needed
-    if (substr(craft()->request->queryString, 0,2) == "p=") {
+    if (substr(craft()->request->queryString, 0, 2) == "p=")
+    {
       $queries = explode("&", craft()->request->queryString, 2);
     }
 
     // Break query apart to separate individual parts
-    if (sizeof($queries) > 1) {
+    if (sizeof($queries) > 1)
+    {
       $queries = explode("&", $queries[1]);
-    } else {
+    } else
+    {
       return false;
     }
 
@@ -71,21 +94,24 @@ class QueryStringsTwigExtension extends Twig_Extension {
     $objectArray = array();
 
     // Loop over query parts and add them to the object
-    foreach ($queries as $query) {
-      $querySplit  = explode("=", $query);
-      if (sizeof($querySplit) > 1) {
-        $queryObject = (object) ['key' => $querySplit[0],'value' => $querySplit[1]];
-        if (($lookForKey != false && $querySplit[0] == $lookForKey) || ($lookForKey == false)) {
-          array_push($objectArray,$queryObject);
+    foreach ($queries as $query)
+    {
+      $querySplit = explode("=", $query);
+      if (sizeof($querySplit) > 1)
+      {
+        $queryObject = (object)['key' => $querySplit[0], 'value' => $querySplit[1]];
+        if (($lookForKey != false && $querySplit[0] == $lookForKey) || ($lookForKey == false))
+        {
+          array_push($objectArray, $queryObject);
         }
-      } 
+      }
     }
 
     // Return objects
     $return = $objectArray;
-    
-    return  $return;
+
+    return $return;
   }
-  
-  
+
+
 }


### PR DESCRIPTION
Should fix #2 Actions in HTML forms can't have query strings on them as the GET fields overwrite those anyway. Added a hidden inputs template variable that can be added to forms (much like `{{ getCsrfInput() }}`)

I've not tested this at all! lol